### PR TITLE
Move currently used frameworks to correct place in paper

### DIFF
--- a/Generic_implementations.tex
+++ b/Generic_implementations.tex
@@ -39,7 +39,7 @@ below.
 The storage framework highlighted above, is one of the most important basis of common implementations used today,
 these implementations are the are frameworks such as Mapreduce and the Apache Spark engine.
 
-\paragraph{1. Map-reduce}
+\paragraph{Map-reduce}
 Map reduce is a new framework for processing data developed by Google\cite{Dean04} in order
 to process data in a distributed setting, the basis behind this is that first all
 data is split into tuples (called key value pairs) in the map phase, which are then passed to the reduce
@@ -66,7 +66,7 @@ that all map-reduce task are so similar to BSP tasks that, becuase BSP has a mor
 basis, all tasks should be modelled as BSP tasks but implemented using the Map-reduce framework
 in order to gain the speed of Map-reduce but the correctness of BSP\cite{Pace12}.
 
-\paragraph{2. Apache Spark}
+\paragraph{Apache Spark}
 Like Map-reduce Apache Spark is another built upon the ability to run programs
 on a distributed dataset. Spark is a machine learning engine that is capable of
 running fully in memory\cite{Sparkwebsite}, this has the advantage that it is a lot faster than

--- a/Generic_implementations.tex
+++ b/Generic_implementations.tex
@@ -1,11 +1,11 @@
-\subsection{Implementations using generic distributed frameworks}
+\subsubsection{Generic distributed system frameworks}
 Distributed system have already been implemented in the industry to solve the
 problem of companies possessing massive amounts of data that they want to be able
 to query and analyze. These frameworks largely rely on the fact that it is cheaper
 to have multiple servers with relatively small storage capacity each in clusters,
 than having one expensive large server.
 
-\subsubsection{The frameworks}
+\paragraph{The frameworks}
 The main basis of existing frameworks is based on the Google File System\cite{Ghem03}. The
 Google File System or GFS is the system that is used within Google to handle all
 the Big data needs in the company. The architecture behind it is that all data that
@@ -35,11 +35,11 @@ below.
   \label{Hadoop_usecase}
 \end{figure}
 
-\subsubsection{Uses of the frameworks}
+\paragraph{Uses of the frameworks}
 The storage framework highlighted above, is one of the most important basis of common implementations used today,
 these implementations are the are frameworks such as Mapreduce and the Apache Spark engine.
 
-\paragraph{Map-reduce}
+\paragraph{1. Map-reduce}
 Map reduce is a new framework for processing data developed by Google\cite{Dean04} in order
 to process data in a distributed setting, the basis behind this is that first all
 data is split into tuples (called key value pairs) in the map phase, which are then passed to the reduce
@@ -66,7 +66,7 @@ that all map-reduce task are so similar to BSP tasks that, becuase BSP has a mor
 basis, all tasks should be modelled as BSP tasks but implemented using the Map-reduce framework
 in order to gain the speed of Map-reduce but the correctness of BSP\cite{Pace12}.
 
-\paragraph{Apache Spark}
+\paragraph{2. Apache Spark}
 Like Map-reduce Apache Spark is another built upon the ability to run programs
 on a distributed dataset. Spark is a machine learning engine that is capable of
 running fully in memory\cite{Sparkwebsite}, this has the advantage that it is a lot faster than

--- a/methods.tex
+++ b/methods.tex
@@ -1,6 +1,5 @@
 \section{Methods}
 
-\input{./Generic_implementations.tex}
 \subsection{Study selection}
 \subsection{Procedure}
 \subsection{Publication bias}

--- a/results.tex
+++ b/results.tex
@@ -130,7 +130,7 @@ There are several network topologies used for Distributed Machine Learning clust
 
 
 \subsection{Currently used implementations}
-\subsubsection{Generic distributed system frameworks}
+\input{./Generic_implementations.tex}
 \subsubsection{Domain-specific implementations}
 \subsubsection{Current challenges}
 


### PR DESCRIPTION
It was under "methods" and should be under "currently used implementations"