### PR TITLE
Fix image layout and add back domain-specific implementations

### DIFF
--- a/Generic_implementations.tex
+++ b/Generic_implementations.tex
@@ -17,7 +17,7 @@ which knows exactly where each chunk is saved.\cite{Ghem03} The Data and workflo
 in figure \ref{GFS_Architecture} below.
 
 \begin{figure}
-  \includegraphics[scale=0.5]{GFS_Architecture.png}
+  \includegraphics[width=\textwidth]{GFS_Architecture.png}
   \caption{Google File System architecture\cite{Ghem03}}
   \label{GFS_Architecture}
 \end{figure}
@@ -30,7 +30,7 @@ adding a file to the Hadoop File System (HDFS) is show in figure \ref{Hadoop_use
 below.
 
 \begin{figure}
-  \includegraphics[scale = 0.5]{Hadoop_use_case.png}
+  \includegraphics[width=\textwidth]{Hadoop_use_case.png}
   \caption{The data flow when adding a file to the HDFS\cite{Shv10}}
   \label{Hadoop_usecase}
 \end{figure}
@@ -50,7 +50,7 @@ which is magnitudes smaller and easier to pass around. The general overview of
 the execution of a map-reduce problem is given in figure \ref{mapreduce_execution}
 
 \begin{figure}
-  \includegraphics[scale=0.5]{mapreduce_execution.png}
+  \includegraphics[width=\textwidth]{mapreduce_execution.png}
   \caption{Overview of the execution of a mapreduce problem\cite{Dean04}}
   \label{mapreduce_execution}
 \end{figure}
@@ -84,7 +84,9 @@ A further note must be made on the lineage graph, as they may not contain a cycl
 and so be a Directed Acyclic Graph (DAG) or else data cannot be recovered.
 
 \begin{figure}
-  \includegraphics[scale = 0.5]{Lineage_graph.png}
+  \begin{center}
+    \includegraphics[scale=0.5]{Lineage_graph.png}
+  \end{center}
   \caption{Example of the lineage graph of an RDD\cite{Zaha12}}
   \label{lineagegraph}
 \end{figure}

--- a/alternatives.tex
+++ b/alternatives.tex
@@ -23,7 +23,7 @@ of the most popular Neural Network Libraries around at the moment. Architecture 
 the chip can be seen in figure \ref{TPU_Architecture}.
 
 \begin{figure}
-  \includegraphics[scale=0.5]{TPU_Architecture.png}
+  \includegraphics[width=\textwidth]{TPU_Architecture.png}
   \caption{Google TPU Architecture\cite{Joup17}}
   \label{TPU_Architecture}
 \end{figure}
@@ -40,7 +40,7 @@ it can be seen that the performance/watt relative to GPUs and CPUs of a TPU is m
 up to nearly 200x the performance/watt.
 
 \begin{figure}
-  \includegraphics[scale=0.5]{TPU_Relative_Performance.png}
+  \includegraphics[width=\textwidth]{TPU_Relative_Performance.png}
   \caption{TPU performance, relative to CPU and GPU, the total performance includes server power costs. GM and WM are geometric and weighted means respectively \cite{Joup17}}
   \label{TPU_Relative_Performance}
 \end{figure}
@@ -50,7 +50,7 @@ than a GPU or CPU in figure \ref{TPU_Performance} where it can be seen that the 
 power of a TPU far outscales a CPU/GPU in most cases.
 
 \begin{figure}
-  \includegraphics[scale=0.5]{TPU_Performance.png}
+  \includegraphics[width=\textwidth]{TPU_Performance.png}
   \caption{TPU performance on 6 common machine learning tasks\cite{Sato17}}
   \label{TPU_Performance}
 \end{figure}
@@ -78,7 +78,7 @@ memory was filled\cite{Rich15}. in figure \ref{Epiphany_MPI} it can be seen that
 until the matrix no longer fits in memory.
 
 \begin{figure}
-  \includegraphics[scale=0.5]{Epiphany_MPI.png}
+  \includegraphics[width=\textwidth]{Epiphany_MPI.png}
   \caption{Epiphany chip performance with different matrix sizes\cite{Rich15}.}
   \label{Epiphany_MPI}
 \end{figure}

--- a/results.tex
+++ b/results.tex
@@ -267,6 +267,7 @@ There are several network topologies used for Distributed Machine Learning clust
 \subsection{Currently used implementations}
 \input{./Generic_implementations.tex}
 \subsubsection{Domain-specific implementations}
+\input{./sections/domain_specific_implementations.tex}
 \subsubsection{Current challenges}
 \paragraph{Performance}
 

--- a/sections/domain_specific_implementations.tex
+++ b/sections/domain_specific_implementations.tex
@@ -1,5 +1,3 @@
-\subsubsection{Domain-specific implementations}
-
 With the rising popularity of applied machine learning in many industries, a variety of domain-specific frameworks have been developed that have distribution models tailored towards ML. In this section, we summarize the characteristics of the most popular implementations.
 
 \paragraph{Distributed ensemble learning}


### PR DESCRIPTION
Most images are now set to the width of a page (although we could scale them back a little where needed).

Some pull request removed the inclusion of the domain-specific implementations section. That's reenabled now.